### PR TITLE
Update for recent changed paths

### DIFF
--- a/susecloud
+++ b/susecloud
@@ -150,11 +150,11 @@ section_header "Crowbar"
 
 pconf_files \
 	/etc/crowbar.install.key \
-	/tmp/bc-template-dns.json \
 	/opt/dell/chef/data_bags/crowbar/bc-template-*.json \
 	/var/chef/cache/chef-stacktrace.out
 find_and_pconf_files /etc/crowbar                         -type f
 find_and_plog_files  /opt/dell/crowbar_framework/log      -type f
+find_and_pconf_files /var/lib/crowbar/config              -type f
 find_and_plog_files  /var/log/nodes                       -type f
 find_and_plog_files  /var/log -path /var/log/crowbar\*    -type f
 find_and_plog_files  /var/log/apache2                     -type f


### PR DESCRIPTION
/tmp/bc-template-dns.json doesn't exist anymore, but we now have several
files in /var/lib/crowbar/config that we want to collect.

Also, /opt/dell/crowbar_framework/log is gone and everything is now in
/var/log/crowbar.
