### PR TITLE
Renaming to SUSE OpenStack Cloud

### DIFF
--- a/susecloud
+++ b/susecloud
@@ -1,8 +1,8 @@
 #!/bin/bash
 #############################################################
-# Name:        Supportconfig Plugin for SUSE Cloud
+# Name:        Supportconfig Plugin for SUSE OpenStack Cloud
 # Description: Gathers important troubleshooting information
-#              about SUSE Cloud
+#              about SUSE OpenStack Cloud
 # License:     GPLv2
 # Author:      Matt Barringer <mbarringer@suse.de>
 # Modified:    2012 August 29
@@ -182,7 +182,7 @@ if [ -n "$SUSECLOUD_PLUGIN_TEST" ]; then
 fi
 
 #############################################################
-section_header "Supportconfig Plugin for SUSE Cloud, v${SVER}"
+section_header "Supportconfig Plugin for SUSE OpenStack Cloud, v${SVER}"
 # The plugin already hardcodes a reference to this directory above, so we're
 # not introducing a new coupling with .spec files by using this absolute path here.
 if [ "$(grep VERSION /etc/SuSE-release 2> /dev/null | sed "s/.*= *//g")" == 12 ]; then

--- a/susecloud-plugin.8
+++ b/susecloud-plugin.8
@@ -1,22 +1,22 @@
 .TH susecloud-plugin "8" "17 Jul 2012" "susecloud-plugin" "Support Utilities Manual"
 .SH NAME
-susecloud-plugin \- SUSE Cloud Plugin for 
+susecloud-plugin \- SUSE OpenStack Cloud Plugin for 
 .BR supportconfig (8)
 .
 .SH DESCRIPTION
-Supportconfig plugins add functionality to the supportconfig script. This plugin extends supportconfig's functionality to include SUSE Cloud
+Supportconfig plugins add functionality to the supportconfig script. This plugin extends supportconfig's functionality to include SUSE OpenStack Cloud
 information. Supportconfig saves the plugin output as plugin-susecloud.txt.
 
 .SH FILES
 .I /usr/lib/supportconfig/plugins/susecloud
 .RS
-The SUSE Cloud plugin
+The SUSE OpenStack Cloud plugin
 .RE
 .SH AUTHOR
 Matt Barringer <mbarringer@suse.de>
 .SH REPORTING BUGS
 Please submit bug fixes, comments or enhancement requests via: 
-.B http://bugzilla.novell.com
+.B http://bugzilla.suse.com
 .SH SEE ALSO
 .BR supportconfig (8)
 .BR supportconfig.conf (5)

--- a/susecloud-rpm-list-sle12
+++ b/susecloud-rpm-list-sle12
@@ -175,6 +175,6 @@ ruby2.1-rubygem-treetop-1_4
 ruby2.1-rubygem-uuidtools
 ruby2.1-rubygem-yajl-ruby
 rubygem-chef
-supportutils-plugin-susecloud
+supportutils-plugin-suse-openstack-cloud
 suse-sle12-cloud-compute-release
 suse-sle12-cloud-compute-release-cd


### PR DESCRIPTION
- change product name to _SUSE OpenStack Cloud_
- change package name to `supportutils-plugin-suse-openstack-cloud`