### PR TITLE
Stop truncating log files

### DIFF
--- a/suse_openstack_cloud
+++ b/suse_openstack_cloud
@@ -10,7 +10,7 @@
 
 SVER=1.0.0
 RCFILE="/usr/lib/supportconfig/resources/scplugin.rc"
-LOG_LINES=10000  # 0 means include the entire file
+LOG_LINES=0  # 0 means include the entire file
 
 if [ -s $RCFILE ]; then
     if ! source $RCFILE; then


### PR DESCRIPTION
It is often very helpful to have the complete log file when debugging a
problem. An example of such a time is when debugging pacemaker resource
failures that occur in an early proposal that did not cause the chef
run to fail but are found later, either by a test in CI or by a
customer. This patch unsets the log file line limit so that the
find_and_plog_files function can grab the entire file rather than just
the last 10000 lines.

An alternative to globally setting the log file limit is to restructure
the script to allow a configurable log line limit depending on the type
of log being collected.