### PR TITLE
Capture couchdb logs

### DIFF
--- a/suse_openstack_cloud
+++ b/suse_openstack_cloud
@@ -276,6 +276,7 @@ echo; echo
 find_and_pconf_files /etc/chef       -type f  ! -name \*.pem
 
 find_and_plog_files  /var/log/chef   -type f
+find_and_plog_files  /var/log/couchdb   -type f
 plog_files 0 \
     /var/chef/cache/chef-stacktrace.out \
     /var/chef/cache/failed-run-data.json


### PR DESCRIPTION
In cases of crowbar installation failures[1] sometimes the crowbar
install log implicates couchdb. This patch makes sure those logs are
captured in addition to the main chef logs.

[1] https://ci.suse.de/job/openstack-mkcloud/79852/console