### PR TITLE
Add monasca-installer.log

### DIFF
--- a/suse_openstack_cloud
+++ b/suse_openstack_cloud
@@ -239,6 +239,7 @@ find_and_pconf_files /var/lib/crowbar/config              -type f
 find_and_plog_files  /var/log/nodes                       -type f
 find_and_plog_files  /var/log -path /var/log/crowbar\*    -type f
 find_and_plog_files  /var/log/apache2                     -type f
+plog_files 0         /var/log/monasca-installer.log
 plugin_tag "admin node PXE / TFTP configuration"
 echo; echo
 find                 /srv/tftpboot                        -maxdepth 1 -ls


### PR DESCRIPTION
This commit adds /var/log/monasca-installer.log to the log files captured on
the Crowbar node. All output from monasca-installer is logged to this file and
without it only a coarse "for some reason monasca-installer failed" diagnos is
possible.

(cherry picked from commit b74e749988b9bc8f8e1c72484f98d4d5ddf558eb)