### PR TITLE
Drop HOS specific packages from SOC list

### DIFF
--- a/suse-openstack-cloud-rpm-list
+++ b/suse-openstack-cloud-rpm-list
@@ -140,7 +140,6 @@ openstack-cinder-doc
 openstack-cinder-scheduler
 openstack-cinder-volume
 openstack-dashboard
-openstack-dashboard-theme-HPE
 openstack-dashboard-theme-SUSE
 openstack-designate
 openstack-designate-agent


### PR DESCRIPTION
No point in checking for those, they won't be available.