### PR TITLE
Change the dir from where the ardana model/config files are collected

### DIFF
--- a/suse_openstack_cloud
+++ b/suse_openstack_cloud
@@ -524,7 +524,8 @@ section_header "ardana"
 
 plog_files 0 /var/lib/ardana/.ansible/ansible.log
 find_and_plog_files_0 \
-    /var/lib/ardana/openstack/my_cloud/definition \
+    /var/lib/ardana/openstack/my_cloud \
+    /var/lib/ardana/scratch/ansible/next/ardana/ansible \
     /var/log/ardana-service/logs                             -type f
 find_and_pconf_files 0 /etc/ardana-service                   -type f
 pconf_files \


### PR DESCRIPTION
Instead of using ~/openstack/my_cloud/definition it is better to
collect do everything from ~/openstack/my_cloud. This provides the
model file as well as all of the *.conf.j2 template files.

Add the collection of the "scratch" dir to capture the last deployment