### PR TITLE
Use mysql root user instead of monitoring

### DIFF
--- a/suse_openstack_cloud
+++ b/suse_openstack_cloud
@@ -304,8 +304,8 @@ if rpm -q mariadb; then
     mariadb_variables_file=/tmp/mariadb_variables
     mariadb_status_file=/tmp/mariadb_status
 
-    mysql -u monitoring -e 'SHOW VARIABLES;' > $mariadb_variables_file
-    mysql -u monitoring -e 'SHOW STATUS;' > $mariadb_status_file
+    mysql -e 'SHOW VARIABLES;' > $mariadb_variables_file
+    mysql -e 'SHOW STATUS;' > $mariadb_status_file
 
     plog_files 0 $mariadb_variables_file
     plog_files 0 $mariadb_status_file


### PR DESCRIPTION
The monitoring user exists only on crowbar installations, so
a couple of mysql commands fail on ardana installations. The
default root user works with crowbar and ardana.